### PR TITLE
1.0.0: add optional message arg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,13 +12,109 @@ dependencies = [
 ]
 
 [[package]]
-name = "getopts"
-version = "0.2.21"
+name = "atty"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "unicode-width",
+ "hermit-abi",
+ "libc",
+ "winapi",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "clap"
+version = "3.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "535434c063ced786eb04aaf529308092c5ab60889e8fe24275d15de07b01fa97"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libc"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 
 [[package]]
 name = "memchr"
@@ -27,18 +123,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+
+[[package]]
 name = "prefix"
 version = "0.1.5"
 dependencies = [
- "getopts",
+ "clap",
  "regex",
 ]
 
 [[package]]
-name = "regex"
-version = "1.5.4"
+name = "proc-macro-error"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "regex"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -52,7 +196,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.9"
+name = "strsim"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "syn"
+version = "1.0.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,9 +118,9 @@ checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "os_str_bytes"
@@ -130,7 +130,7 @@ checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 
 [[package]]
 name = "prefix"
-version = "0.1.5"
+version = "1.0.0"
 dependencies = [
  "clap",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "prefix"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "getopts",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prefix"
-version = "0.1.5"
+version = "1.0.0"
 authors = ["Shivix"]
 edition = "2018"
 description = "A pretty printer for FIX messages"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prefix"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Shivix"]
 edition = "2018"
 description = "A pretty printer for FIX messages"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,5 @@ categories = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-regex = "1.5.4"
-getopts = "0.2.21"
-
+regex = "1.5.5"
+clap = { version = "3.1.14", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # PREtty FIX
-
 A commandline based pretty printer for FIX messages.
 
 ## Usage
-pipe other commands into or out of prefix to use.
-
-example:
-```
+Mainly developed with unix piping in mind:
+```bash
 echo 8=4.4^1=test | prefix
+```
+But can also provide a message as an argument:
+```bash
+prefix 8=4.4^1=test
 ```
 
 outputs:

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,8 +58,7 @@ fn main() {
         .read_to_string(&mut input)
         .expect("Could not read input");
 
-    match prefix::run(input, value_flag, delimiter) {
-        Err(x) => eprintln!("{}", x),
-        _ => {}
-    };
+    if let Err(x) = prefix::run(input, value_flag, delimiter) {
+        eprintln!("{}", x)
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,55 +1,21 @@
 mod prefix;
+use clap::Parser;
 use std::io::{self, Read};
-extern crate getopts;
-use getopts::Options;
 
-fn print_usage(program: &str, opts: Options) {
-    let brief = format!(
-        "Usage: {} [options]
-        Pretty prints fix messages in a more human readable manner
-        Pipe other commands into or out of prefix to use",
-        program
-    );
-    print!("{}", opts.usage(&brief));
+#[derive(Parser)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// set delimiter string to print after each FIX field
+    #[clap(short, long, default_value = "\n")]
+    delimiter: String,
+
+    /// translate common FIX values (for Side: 1 -> Buy)
+    #[clap(short, long)]
+    value: bool,
 }
 
 fn main() {
-    let argv: Vec<String> = std::env::args().collect();
-    let program = argv[0].clone();
-
-    let mut opts = Options::new();
-    opts.optopt(
-        "d",
-        "delimiter",
-        "set delimiter string to print after each FIX fields",
-        "STRING",
-    );
-    opts.optflag(
-        "v",
-        "value",
-        "translate common FIX values (for Side: 1 -> Buy)",
-    );
-    opts.optflag("h", "help", "print this help menu");
-
-    let matches = match opts.parse(&argv[1..]) {
-        Ok(m) => m,
-        Err(f) => std::panic::panic_any(f.to_string()),
-    };
-
-    if matches.opt_present("h") {
-        print_usage(&program, opts);
-        return;
-    }
-
-    let mut delimiter = String::from("\n");
-    if matches.opt_present("d") {
-        delimiter = matches.opt_str("d").expect("bad delimiter string");
-    }
-
-    let mut value_flag = false;
-    if matches.opt_present("v") {
-        value_flag = true;
-    }
+    let args = Args::parse();
 
     // stdin is used to allow piping with other commands
     let mut stdin = io::stdin();
@@ -58,7 +24,7 @@ fn main() {
         .read_to_string(&mut input)
         .expect("Could not read input");
 
-    if let Err(x) = prefix::run(input, value_flag, delimiter) {
+    if let Err(x) = prefix::run(input, args.value, args.delimiter) {
         eprintln!("{}", x)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,11 +5,13 @@ use std::io::{self, Read};
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
-    /// set delimiter string to print after each FIX field
+    /// FIX message to be parsed. If not provided will look for a message piped through stdin.
+    message: Option<String>,
+    /// Set delimiter string to print after each FIX field.
     #[clap(short, long, default_value = "\n")]
     delimiter: String,
 
-    /// translate common FIX values (for Side: 1 -> Buy)
+    /// Translate common FIX values. (for Side: 1 -> Buy)
     #[clap(short, long)]
     value: bool,
 }
@@ -17,14 +19,19 @@ struct Args {
 fn main() {
     let args = Args::parse();
 
-    // stdin is used to allow piping with other commands
-    let mut stdin = io::stdin();
-    let mut input = String::new();
-    stdin
-        .read_to_string(&mut input)
-        .expect("Could not read input");
+    let fix_message = match args.message {
+        Some(msg) => msg,
+        None => {
+            // stdin is used to allow piping with other commands
+            let mut input = String::new();
+            io::stdin()
+                .read_to_string(&mut input)
+                .expect("could not read input");
+            input
+        }
+    };
 
-    if let Err(x) = prefix::run(input, args.value, args.delimiter) {
+    if let Err(x) = prefix::run(fix_message, args.value, args.delimiter) {
         eprintln!("{}", x)
     }
 }

--- a/src/prefix/mod.rs
+++ b/src/prefix/mod.rs
@@ -93,11 +93,11 @@ fn parse(input: String) -> Result<Vec<Field>, &'static str> {
     let regex = Regex::new(r"(?P<tag>[0-9]+)=(?P<value>[^\^\|\x01]+)").expect("Bad regex");
     let mut result = Vec::<Field>::new();
 
-    if !regex.is_match(&input) {
+    if !regex.is_match(input) {
         return Err("Could not find a valid FIX message");
     }
 
-    for i in regex.captures_iter(&input) {
+    for i in regex.captures_iter(input) {
         result.push(Field {
             tag: FromStr::from_str(&i["tag"]).expect("Could not parse tag"),
             value: i["value"].to_string(),
@@ -139,29 +139,50 @@ fn print(input: String) {
 // Can refactor and add a translated values field to the TAGS map in the future
 #[rustfmt::skip]
 fn translate_value(field: Field) -> String {
-    if field.tag == 54 { // Side
-        if field.value == "1" { return String::from("Buy"); }
-        if field.value == "2" { return String::from("Sell"); }
-    } else if field.tag == 269 { // MDEntryType
-        if field.value == "0" { return String::from("Bid"); }
-        if field.value == "1" { return String::from("Offer"); }
-        if field.value == "2" { return String::from("Trade"); }
-    } else if field.tag == 59 { // TimeInForce
-        if field.value == "0" { return String::from("Day"); }
-        if field.value == "1" { return String::from("GTC"); }
-        if field.value == "2" { return String::from("OPG"); }
-        if field.value == "3" { return String::from("IOC"); }
-        if field.value == "4" { return String::from("FOK"); }
-        if field.value == "5" { return String::from("GTX"); }
-        if field.value == "6" { return String::from("GTC"); }
-    } else if field.tag == 279 { // MDEntryType
-        if field.value == "0" { return String::from("New"); }
-        if field.value == "1" { return String::from("Change"); }
-        if field.value == "2" { return String::from("Delete"); }
-    } else if field.tag == 263 { // MDEntryType
-        if field.value == "0" { return String::from("Snapshot"); }
-        if field.value == "1" { return String::from("Subscribe"); }
-        if field.value == "2" { return String::from("Unsubscribe"); }
+    match field.tag {
+        54 => { // Side
+            match field.value.as_str() {
+                "1" => String::from("Buy"),
+                "2" => String::from("Sell"),
+                _ => field.value
+            }
+        }
+        59 => { // TimeInForce
+            match field.value.as_str() {
+                "0" => String::from("Day"),
+                "1" => String::from("GTC"),
+                "2" => String::from("OPG"),
+                "3" => String::from("IOC"),
+                "4" => String::from("FOK"),
+                "5" => String::from("GTX"),
+                "6" => String::from("GTD"),
+                _ => field.value
+            }
+        }
+        263 => { // SubscriptionRequestType
+            match field.value.as_str() {
+                "0" => String::from("Snapshot"),
+                "1" => String::from("Subscribe"),
+                "2" => String::from("Unsubscribe"),
+                _ => field.value
+            }
+        }
+        269 => { // MDEntryType
+            match field.value.as_str() {
+                "0" => String::from("Bid"),
+                "1" => String::from("Offer"),
+                "2" => String::from("Trade"),
+                _ => field.value
+            }
+        }
+        279 => { // MDUpdateAction
+            match field.value.as_str() {
+                "0" => String::from("New"),
+                "1" => String::from("Change"),
+                "2" => String::from("Delete"),
+                _ => field.value
+            }
+        }
+        _ => field.value
     }
-    field.value
 }

--- a/src/prefix/mod.rs
+++ b/src/prefix/mod.rs
@@ -90,7 +90,7 @@ pub fn run(input: String, value_flag: bool, delimiter: String) -> Result<(), &'s
 fn parse(input: String) -> Result<Vec<Field>, &'static str> {
     let input = input.trim();
     // matches against a number followed by an = followed by anything excluding the given delimiters
-    let regex = Regex::new(r"(?P<tag>[0-9]+)=(?P<value>[^\^\|\x01]+)").expect("Bad regex");
+    let regex = Regex::new(r"(?P<tag>[0-9]+)=(?P<value>[^\^\|\x01]+)").expect("bad regex");
     let mut result = Vec::<Field>::new();
 
     if !regex.is_match(input) {
@@ -99,7 +99,7 @@ fn parse(input: String) -> Result<Vec<Field>, &'static str> {
 
     for i in regex.captures_iter(input) {
         result.push(Field {
-            tag: FromStr::from_str(&i["tag"]).expect("Could not parse tag"),
+            tag: FromStr::from_str(&i["tag"]).expect("could not parse tag"),
             value: i["value"].to_string(),
         })
     }
@@ -110,7 +110,7 @@ fn format_to_string(input: Vec<Field>, value_flag: bool, delimiter: String) -> S
     let mut result = String::new();
 
     for i in input {
-        // incase any non standard tags are used
+        // allow custom tags to still be printed without translation
         if i.tag as usize >= tags::TAGS.len() {
             result.push_str(&i.tag.to_string());
         } else {
@@ -132,57 +132,50 @@ fn print(input: String) {
     let mut handle = stdout.lock();
     handle
         .write_all(input.as_bytes())
-        .expect("Could not print to stdout");
+        .expect("could not print to stdout");
 }
 
-// not ideal but leaves it simple and easy for anyone to add values. This function is opt in.
-// Can refactor and add a translated values field to the TAGS map in the future
-#[rustfmt::skip]
+// Not ideal but leaves it simple and easy for anyone to add values. This function is opt in.
 fn translate_value(field: Field) -> String {
     match field.tag {
-        54 => { // Side
-            match field.value.as_str() {
-                "1" => String::from("Buy"),
-                "2" => String::from("Sell"),
-                _ => field.value
-            }
-        }
-        59 => { // TimeInForce
-            match field.value.as_str() {
-                "0" => String::from("Day"),
-                "1" => String::from("GTC"),
-                "2" => String::from("OPG"),
-                "3" => String::from("IOC"),
-                "4" => String::from("FOK"),
-                "5" => String::from("GTX"),
-                "6" => String::from("GTD"),
-                _ => field.value
-            }
-        }
-        263 => { // SubscriptionRequestType
-            match field.value.as_str() {
-                "0" => String::from("Snapshot"),
-                "1" => String::from("Subscribe"),
-                "2" => String::from("Unsubscribe"),
-                _ => field.value
-            }
-        }
-        269 => { // MDEntryType
-            match field.value.as_str() {
-                "0" => String::from("Bid"),
-                "1" => String::from("Offer"),
-                "2" => String::from("Trade"),
-                _ => field.value
-            }
-        }
-        279 => { // MDUpdateAction
-            match field.value.as_str() {
-                "0" => String::from("New"),
-                "1" => String::from("Change"),
-                "2" => String::from("Delete"),
-                _ => field.value
-            }
-        }
-        _ => field.value
+        // Side
+        54 => match field.value.as_str() {
+            "1" => String::from("Buy"),
+            "2" => String::from("Sell"),
+            _ => field.value,
+        },
+        // TimeInForce
+        59 => match field.value.as_str() {
+            "0" => String::from("Day"),
+            "1" => String::from("GTC"),
+            "2" => String::from("OPG"),
+            "3" => String::from("IOC"),
+            "4" => String::from("FOK"),
+            "5" => String::from("GTX"),
+            "6" => String::from("GTD"),
+            _ => field.value,
+        },
+        // SubscriptionRequestType
+        263 => match field.value.as_str() {
+            "0" => String::from("Snapshot"),
+            "1" => String::from("Subscribe"),
+            "2" => String::from("Unsubscribe"),
+            _ => field.value,
+        },
+        // MDEntryType
+        269 => match field.value.as_str() {
+            "0" => String::from("Bid"),
+            "1" => String::from("Offer"),
+            "2" => String::from("Trade"),
+            _ => field.value,
+        },
+        // MDUpdateAction
+        279 => match field.value.as_str() {
+            "0" => String::from("New"),
+            "1" => String::from("Change"),
+            "2" => String::from("Delete"),
+            _ => field.value,
+        },
+        _ => field.value,
     }
 }


### PR DESCRIPTION
Does some general code clean up, including switching to clap for arg parsing.

Uses clap to add a new optional argument that can be provided to allow parsing a fix message without piping other commands into prefix. Should make prefix a lot more usable outside of UNIX based systems.

Also marks the "official" 1.0 release. I've been using this for a while now and it's definitely filled my requirements. Nevertheless I will continue some light development here and there and am open to suggestions on new features/ changes.