### PR TITLE
v1.0.3: Improve printing multiple fix messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
 name = "prefix"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prefix"
-version = "1.0.2"
+version = "1.0.3"
 authors = ["Shivix"]
 edition = "2021"
 description = "A customizable pretty printer for FIX messages"

--- a/completion/_prefix
+++ b/completion/_prefix
@@ -23,7 +23,7 @@ _prefix() {
 '--version[Print version information]' \
 '-v[Translate common FIX values (for Side: 1 -> Buy)]' \
 '--value[Translate common FIX values (for Side: 1 -> Buy)]' \
-'::message -- FIX message to be parsed, if not provided will look for a message piped through stdin:' \
+'*::message -- FIX message to be parsed, if not provided will look for a message piped through stdin:' \
 && ret=0
 }
 

--- a/completion/prefix.bash
+++ b/completion/prefix.bash
@@ -19,7 +19,7 @@ _prefix() {
 
     case "${cmd}" in
         prefix)
-            opts="-h -V -d -v --help --version --delimiter --value <message>"
+            opts="-h -V -d -v --help --version --delimiter --value <message>..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/man/prefix.1
+++ b/man/prefix.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH prefix 1  "prefix 1.0.1" 
+.TH prefix 1  "prefix 1.0.3" 
 .SH NAME
 prefix \- A customizable pretty printer for FIX messages
 .SH SYNOPSIS
@@ -25,4 +25,4 @@ Translate common FIX values (for Side: 1 \-> Buy)
 [\fImessage\fR]
 FIX message to be parsed, if not provided will look for a message piped through stdin
 .SH VERSION
-v1.0.1
+v1.0.3

--- a/src/command.rs
+++ b/src/command.rs
@@ -4,7 +4,7 @@ pub fn make_command() -> Command<'static> {
     Command::new("prefix")
         .about("A customizable pretty printer for FIX messages")
         .version(env!("CARGO_PKG_VERSION"))
-        .arg(Arg::new("message").help(
+        .arg(Arg::new("message").multiple_occurrences(true).help(
             "FIX message to be parsed, if not provided will look for a message piped through stdin",
         ))
         .arg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,9 @@ use std::io::{self, Read};
 fn main() {
     let matches = command::make_command().get_matches();
 
-    let fix_message = match matches.value_of("message") {
-        Some(msg) => msg.to_string(),
+    let fix_message = match matches.values_of("message") {
+        // If multiple messages are provided, simply combine them with |
+        Some(msg) => msg.map(|elem| elem.to_string() + "|").collect(),
         None => {
             // stdin is used to allow piping with other commands
             let mut input = String::new();

--- a/src/prefix/mod.rs
+++ b/src/prefix/mod.rs
@@ -64,18 +64,30 @@ mod tests {
 
     #[test]
     fn format_case() {
-        let input = "8=FIX.4.4^1=test^55=ETH/USD^54=1";
+        let input = "8=FIX.4.4^1=test^55=ETH/USD^54=1^29999=50";
         let parsed = parse(input).unwrap();
         let result = format_to_string(parsed, true, "|");
+        let expected = String::from(
+            "BeginString = FIX.4.4|Account = test|Symbol = ETH/USD|Side = Buy|29999 = 50|",
+        );
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn multiple_message_case() {
+        let input =
+            "8=FIX.4.2|1=ACCOUNT|299=1234^55=USDJPY\n8=FIX.4.4|1=ACCOUNT2|299=4321|55=EURJPY|";
+        let parsed = parse(input).unwrap();
+        let result = format_to_string(parsed, true, "| ");
         let expected =
-            String::from("BeginString = FIX.4.4|Account = test|Symbol = ETH/USD|Side = Buy|");
+            String::from("BeginString = FIX.4.2| Account = ACCOUNT| QuoteEntryID = 1234| Symbol = USDJPY| \nBeginString = FIX.4.4| Account = ACCOUNT2| QuoteEntryID = 4321| Symbol = EURJPY| ");
         assert_eq!(result, expected);
     }
 }
 
 #[derive(Debug, PartialEq)]
 struct Field {
-    tag: i32,
+    tag: usize,
     value: String,
 }
 
@@ -89,7 +101,8 @@ pub fn run(input: &str, value_flag: bool, delimiter: &str) -> Result<(), &'stati
 fn parse(input: &str) -> Result<Vec<Field>, &'static str> {
     let input = input.trim();
     // matches against a number followed by an = followed by anything excluding the given delimiters
-    let regex = Regex::new(r"(?P<tag>[0-9]+)=(?P<value>[^\^\|\x01]+)").expect("bad regex");
+    // Current delimiters used: ^ | SOH \n
+    let regex = Regex::new(r"(?P<tag>[0-9]+)=(?P<value>[^\^\|\x01\n]+)").expect("bad regex");
     let mut result = Vec::<Field>::new();
 
     if !regex.is_match(input) {
@@ -108,20 +121,28 @@ fn parse(input: &str) -> Result<Vec<Field>, &'static str> {
 
 fn format_to_string(input: Vec<Field>, value_flag: bool, delimiter: &str) -> String {
     let mut result = String::new();
-
+    let mut msg_counter = 0;
     for i in input {
+        /* makes it easier to mentally parse seperate messages with default args and easier to
+         * computationally parse when using a delimiter such as | ensures each message is on its
+         * own line */
+        if i.tag == 8 {
+            msg_counter += 1;
+            if msg_counter > 1 {
+                result.push('\n');
+            }
+        }
         // Allow custom tags to still be printed without translation
-        if i.tag as usize >= tags::TAGS.len() {
+        if i.tag >= tags::TAGS.len() {
             result.push_str(&i.tag.to_string());
         } else {
-            result.push_str(tags::TAGS[i.tag as usize]);
+            result.push_str(tags::TAGS[i.tag]);
         }
         result.push_str(" = ");
-        if value_flag {
-            result.push_str(&translate_value(i));
-        } else {
-            result.push_str(&i.value);
-        }
+        result.push_str(match value_flag {
+            true => translate_value(&i),
+            false => &i.value,
+        });
         result.push_str(delimiter);
     }
     result
@@ -136,66 +157,66 @@ fn print(input: String) {
 }
 
 // Not ideal but leaves it simple and easy for anyone to add values. This function is opt in.
-fn translate_value(field: Field) -> String {
+fn translate_value(field: &Field) -> &str {
     match field.tag {
         // OrdType
         40 => match field.value.as_str() {
-            "1" => String::from("Market"),
-            "2" => String::from("Limit"),
-            "3" => String::from("Stop"),
+            "1" => "Market",
+            "2" => "Limit",
+            "3" => "Stop",
             // Keep as one word for better usage with awk
-            "4" => String::from("StopLimit"),
-            "D" => String::from("PreviouslyQuoted"),
-            _ => field.value,
+            "4" => "StopLimit",
+            "D" => "PreviouslyQuoted",
+            _ => &field.value,
         },
         // Side
         54 => match field.value.as_str() {
-            "1" => String::from("Buy"),
-            "2" => String::from("Sell"),
-            _ => field.value,
+            "1" => "Buy",
+            "2" => "Sell",
+            _ => &field.value,
         },
         // TimeInForce
         59 => match field.value.as_str() {
-            "0" => String::from("Day"),
-            "1" => String::from("GTC"),
-            "2" => String::from("OPG"),
-            "3" => String::from("IOC"),
-            "4" => String::from("FOK"),
-            "5" => String::from("GTX"),
-            "6" => String::from("GTD"),
-            _ => field.value,
+            "0" => "Day",
+            "1" => "GTC",
+            "2" => "OPG",
+            "3" => "IOC",
+            "4" => "FOK",
+            "5" => "GTX",
+            "6" => "GTD",
+            _ => &field.value,
         },
         // ExecType
         150 => match field.value.as_str() {
-            "0" => String::from("New"),
-            "1" => String::from("PartialFill"),
-            "2" => String::from("Fill"),
-            "4" => String::from("Canceled"),
-            "8" => String::from("Rejected"),
-            "F" => String::from("Trade"),
-            _ => field.value,
+            "0" => "New",
+            "1" => "PartialFill",
+            "2" => "Fill",
+            "4" => "Canceled",
+            "8" => "Rejected",
+            "F" => "Trade",
+            _ => &field.value,
         },
         // SubscriptionRequestType
         263 => match field.value.as_str() {
-            "0" => String::from("Snapshot"),
-            "1" => String::from("Subscribe"),
-            "2" => String::from("Unsubscribe"),
-            _ => field.value,
+            "0" => "Snapshot",
+            "1" => "Subscribe",
+            "2" => "Unsubscribe",
+            _ => &field.value,
         },
         // MDEntryType
         269 => match field.value.as_str() {
-            "0" => String::from("Bid"),
-            "1" => String::from("Offer"),
-            "2" => String::from("Trade"),
-            _ => field.value,
+            "0" => "Bid",
+            "1" => "Offer",
+            "2" => "Trade",
+            _ => &field.value,
         },
         // MDUpdateAction
         279 => match field.value.as_str() {
-            "0" => String::from("New"),
-            "1" => String::from("Change"),
-            "2" => String::from("Delete"),
-            _ => field.value,
+            "0" => "New",
+            "1" => "Change",
+            "2" => "Delete",
+            _ => &field.value,
         },
-        _ => field.value,
+        _ => &field.value,
     }
 }


### PR DESCRIPTION
Allows taking in multiple fix messages through CLI arguments to better match stdin behavior.
Improves printing of multiple FIX messages. Will now add a newline between each message. Improves human parsing with default arguments and improves machine parsing with custom delimiters. (can easily have a message per line now)